### PR TITLE
Prompt to /dev/tty

### DIFF
--- a/files/plugins/discovery/foreman.rb
+++ b/files/plugins/discovery/foreman.rb
@@ -60,12 +60,15 @@ module MCollective
       end
 
       def self.authenticate_user
-        puts "Username: "
+        fd = IO.sysopen "/dev/tty", "w"
+        ios = IO.new(fd, "w")
+        ios.puts "Username: "
         username = gets.chomp
-        puts "Password: "
-        system `stty -echo` 
+        ios.puts "Password: "
+        system `stty -echo`
         password = gets.chomp
-        system `stty echo` 
+        system `stty echo`
+        ios.close
 
         { :login => username, :password => password }
       end


### PR DESCRIPTION
Make sure prompt is printed even when mco is piped to xargs or similar
