### PR TITLE
to fix problem reported in issue #8 do not hardcode ssl_ca

### DIFF
--- a/discovery/foreman.rb
+++ b/discovery/foreman.rb
@@ -17,7 +17,7 @@ module MCollective
         :timeout      => 7,
         :storeconfigs => false,
         # if CA is specified, remote Foreman host will be verified 
-        :ssl_ca       => "/var/lib/puppet/ssl/certs/ca.pem",
+        :ssl_ca       => Config.instance.pluginconf["foreman.ssl_ca"] || "/var/lib/puppet/ssl/certs/ca.pem",
         # ssl_cert and key are required if require_ssl_puppetmasters is enabled in Foreman 
         :ssl_cert     => Config.instance.pluginconf["foreman.ssl_cert"] || "",
         :ssl_key      => Config.instance.pluginconf["foreman.ssl_key"] || "",

--- a/templates/config.cfg.erb
+++ b/templates/config.cfg.erb
@@ -1,5 +1,6 @@
 plugin.foreman.url = foremanurlandport
 plugin.foreman.ssl_cert = /var/lib/puppet/ssl/certs/<%= fqdn %>.pem
 plugin.foreman.ssl_key  = /var/lib/puppet/ssl/private_keys/<%= fqdn %>.pem
+plugin.foreman.ssl_ca = /var/lib/puppet/ssl/certs/ca.pem
 plugin.foreman.use_krb  = 0
 direct_addressing = 1


### PR DESCRIPTION
To fix problem reported in issue #8, avoid hardcoding ssl_ca.
The default behaviour is the same as before.